### PR TITLE
feat: update getIsOnline function to use no-cors mode for fetch requests

### DIFF
--- a/src/utils/getIsOnline.ts
+++ b/src/utils/getIsOnline.ts
@@ -9,8 +9,8 @@ export async function getIsOnline(address: string) {
   const results = await Promise.allSettled(
     addresses.map(async (ip) => {
       try {
-        const res = await fetch(ip, { signal: AbortSignal.timeout(5000) })
-        return res.ok
+        await fetch(ip, { signal: AbortSignal.timeout(5000), mode: "no-cors",})
+        return true
       } catch (err) {
         console.error('Error checking online status for', ip, err)
         return false


### PR DESCRIPTION
This pull request updates the `getIsOnline` utility function to improve how it checks the online status of given addresses. The main change is to use the `"no-cors"` mode in the `fetch` request and to treat any successful fetch (without error) as an indication that the address is online, regardless of the HTTP response status.

**Improvements to online status check:**

* Updated the `fetch` call in `getIsOnline` to use `mode: "no-cors"`, and now considers any successful fetch (i.e., no thrown error) as online, instead of relying on the HTTP response's `ok` status.