### PR TITLE
fix: improve fetch options for online status check

### DIFF
--- a/src/utils/getIsOnline.ts
+++ b/src/utils/getIsOnline.ts
@@ -20,7 +20,12 @@ export async function getIsOnline({
     addresses.map(async (ip) => {
       try {
         updateItemLoading(ip, true)
-        await fetch(ip, { signal: AbortSignal.timeout(5000), mode: 'no-cors' })
+        const hasNoCors = !ip.endsWith('7000')
+        const options = {
+          signal: AbortSignal.timeout(5000),
+          mode: hasNoCors ? 'no-cors' : 'cors',
+        } as RequestInit
+        await fetch(ip, options)
         updateItemStatus(ip, true)
 
         return true


### PR DESCRIPTION
Percebi que o padrão do `nexus` não funciona com o `no-cors`, ou seja, mesmo que um nexus estivesse ativo, no Serveruler ele aparecia inativo.

Adicionei uma nova validação para garantir que apareça ativo, corretamente

### Atualmente:
<img width="299" height="220" alt="image" src="https://github.com/user-attachments/assets/5e1cfec7-1122-4d91-9611-d92ba8afcb6a" />

### Após alterações:
<img width="331" height="271" alt="image" src="https://github.com/user-attachments/assets/ce1a2214-2b20-4ce6-b872-a7cf4524def1" />
